### PR TITLE
small dataset - singular matrix error fix

### DIFF
--- a/star/views.py
+++ b/star/views.py
@@ -323,14 +323,22 @@ def analyze():
     try:
         analysis = Analysis()
         results = analysis.analyze(model.data_frame)
-    except Exception:
-        results = {
-            "error": "We ran into some trouble while analyzing your data. "
-            "This can be caused by having too little data. We've "
-            "recorded the error and will investigate it further. If "
-            "you have any questions, please email toolhelp@rti.org."
-        }
-        sentry.captureException(extra=session)
+    except Exception as e:
+        # Using singular matrix because some datasets are complete enough
+        # to preform analysis (ie. +/- 30 days NOT checked)
+        if (str(e) == "Singular matrix"):
+            results = {
+                "error": "Please use a larger dataset to preform the analysis."
+                " If you have any questions, please email toolhelp@rti.org."
+            }
+        else:
+            results = {
+                "error": "We ran into some trouble while analyzing your data. "
+                "This can be caused by having too little data. We've "
+                "recorded the error and will investigate it further. If "
+                "you have any questions, please email toolhelp@rti.org."
+            }
+            sentry.captureException(extra=session)
 
     min_twilight, max_twilight = model.find_twilight_range()
     itp_range = "{} - {}".format(


### PR DESCRIPTION
When a dataset that is too small for analysis and the `Restrict dates to +/- 30 days from Daylight Savings Time start and end` checkbox is checked, users are seeing an error screen.

This is because the analysis was encountering a Numpy`Singular matrix` error. In short (as discussed with Peter,) these occur when there is not enough data to preform statical analysis. In addition, the sentry `captureException` could not record a Numpy `Singular matrix` error so the application would break and then display the error page. 

This fix checks whether the error is a `Singular matrix` error, and, if so, provides the user with an error message simply telling them to provide a larger dataset and properly handles the exception.