### PR TITLE
use instance instead of class for logit family

### DIFF
--- a/star/analysis.py
+++ b/star/analysis.py
@@ -81,7 +81,7 @@ class Analysis:
                 officer_formula,
                 "officerid",
                 df,
-                family=sm.families.Binomial(sm.families.links.logit),
+                family=sm.families.Binomial(sm.families.links.logit()),
                 cov_struct=sm.cov_struct.Exchangeable(),
             )
 


### PR DESCRIPTION
I believe the analysis was breaking because we were using the `logit` class instead of an instance of it.

See the statsmodels docs for a reference to the error we were getting and what it is expecting instead:
`# link property for each family is a pointer to link instance`
https://www.statsmodels.org/stable/_modules/statsmodels/genmod/families/family.html

The error we were getting was:
`TypeError: Calling Family(..) with a link class is not allowed. Use an instance of a link class instead`