### PR TITLE
Update deployment docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,12 +70,14 @@ To deploy the app, do the following steps:
     - There should be a `rti-star<TAG_NUMBER>.tar.gz`
     - If there is not, then from the `rti-star` directory run `docker save rti-star:<TAG_NUMBER> | gzip > backup/rti-star<TAG_NUMBER>.tar.gz`
 
-- From your local environment, save the updated docker image: `docker save rt-star:<NEW_TAG_NUMBER> | gzip > rti-star<NEW_TAG_NUMBER>.tar.gz`
+- From your local environment, build the image if you haven't already: `docker-compose build`
+- give the image the appropriate name and tag: `docker tag star_app rti-star:<NEW_TAG_NUMBER>`
+- save the updated docker image: `docker save rti-star:<NEW_TAG_NUMBER> | gzip > rti-star<NEW_TAG_NUMBER>.tar.gz`
     - (`NEW_TAG_NUMBER` = 1 + `TAG_NUMBER`)
 - scp the new image to mallard: `scp path/to/rti-star<NEW_TAG_NUMBER>.tar.gz <USER>@<CDS_MALLARD_HOST>:~/`
 - ssh into mallard: `ssh <USER>@<CDS_MALLARD_HOST>`
-- `sudo su gitlab-runner`
 - scp the new image to cfs-production: `sudo scp -i ~/.ssh/cfs-production-admin.pem rti-star<NEW_TAG_NUMBER>.tar.gz <CFS_PRODUCTION_USER>@<CFS_PRODUCTION_HOST>:~/rti-star/backup`
+- `sudo su gitlab-runner`
 - ssh into cfs-production: `ssh -i ~/.ssh/cfs-production-admin.pem <CFS_PRODUCTION_USER>@<CFS_PRODUCTION_HOST>`
 - Go to the `rti-star` directory: `cd rti-star`
 - Load the new image: `docker load --input backup/rti-star<NEW_TAG_NUMBER>.tar.gz`

--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ To deploy the app, do the following steps:
 
 - From your local environment, build the image if you haven't already: `docker-compose build`
 - give the image the appropriate name and tag: `docker tag star_app rti-star:<NEW_TAG_NUMBER>`
-- save the updated docker image: `docker save rti-star:<NEW_TAG_NUMBER> | gzip > rti-star<NEW_TAG_NUMBER>.tar.gz`
     - (`NEW_TAG_NUMBER` = 1 + `TAG_NUMBER`)
+- save the updated docker image: `docker save rti-star:<NEW_TAG_NUMBER> | gzip > rti-star<NEW_TAG_NUMBER>.tar.gz`
 - scp the new image to mallard: `scp path/to/rti-star<NEW_TAG_NUMBER>.tar.gz <USER>@<CDS_MALLARD_HOST>:~/`
 - ssh into mallard: `ssh <USER>@<CDS_MALLARD_HOST>`
 - scp the new image to cfs-production: `sudo scp -i ~/.ssh/cfs-production-admin.pem rti-star<NEW_TAG_NUMBER>.tar.gz <CFS_PRODUCTION_USER>@<CFS_PRODUCTION_HOST>:~/rti-star/backup`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,3 +6,4 @@ services:
       - "0.0.0.0:5000:5000"
     volumes:
       - .:/app
+    platform: linux/amd64


### PR DESCRIPTION
I walked through the deployment steps in the readme and had just a couple small changes that helped me.

- `docker-compose.yml` :  I added a platform specification for the build (`linux/amd64`). This helped me (and likely future devs) on M1 Macs prevent building ARM images for this application which will fail when packaged and deployed to EC2. Many ways to do this so happy to implement it differently

- `README.md`: 
     - when the app is built with `docker-compose build`, the image is automatically named `star_app`. Downstream docker tasks depend on the image to be named `rti-star:<NEW-TAG-NUMBER>`, so I figured the easiest fix was to add a `docker tag` step to the deployment procedure
     - to `scp` the image file to `cfs-prod`, I needed to be my personal user on mallard, not gitlab-runner (who doesn't have access to user folders). So I just moved the `sudo su gitlab-runner` to the line after that step
